### PR TITLE
Fix issue with serial number extraction

### DIFF
--- a/comitup/config.py
+++ b/comitup/config.py
@@ -126,7 +126,7 @@ def load_data():
             data['mac'] = _get_mac()
 
         if spec.group().startswith('<s'):
-            data['sn']: _getserial()
+            data['sn'] = _getserial()
 
     log.debug(data)
     return (conf, data)


### PR DESCRIPTION
The  Access Point serial number was not handled properly due to a typo in the config script.